### PR TITLE
Fixes error in spec

### DIFF
--- a/test/index-test.js
+++ b/test/index-test.js
@@ -150,7 +150,7 @@ describe('Rock Dodger', () => {
     })
 
     it('removes the "keydown" event listener', () => {
-      const spy = expect.spyOn(document, 'removeEventListener')
+      const spy = expect.spyOn(window, 'removeEventListener')
 
       endGame()
 


### PR DESCRIPTION
This event listener was originally added to window, not document. If you pass the spec, then the listener isn't actually removed as currently written.